### PR TITLE
Remove unnecessary clippy argument

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,7 +34,7 @@ jobs:
         run: cargo install clippy-sarif sarif-fmt
       - name: Run clippy
         run: >
-          cargo clippy --all-features --all --no-deps --message-format=json
+          cargo clippy --all-features --all --message-format=json
           | clippy-sarif
           | tee clippy-results.sarif
           | sarif-fmt


### PR DESCRIPTION
As we want to analyze the whole workspace, there is no need for the "--no-deps" argument.